### PR TITLE
[mimir-distributed] Update nginx/_helpers.tpl

### DIFF
--- a/charts/mimir-distributed/templates/nginx/_helpers.tpl
+++ b/charts/mimir-distributed/templates/nginx/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-nginx fullname
+nginx Fullname
 */}}
 {{- define "mimir.nginxFullname" -}}
 {{ include "mimir.fullname" . }}-nginx


### PR DESCRIPTION
Correct charts/mimir-distributed/templates/nginx/_helpers.tpl to define mimir.nginxFullname based off mimir.fullname . Currently helm deployment will fail if ingress is enabled in value file as noted in Issue #1244

Signed-off-by: Brandon Abernathy Brandon.Abernathy@BecksHybrids.com